### PR TITLE
fix: remove destroy all windows from video detection

### DIFF
--- a/colordetect/video_color_detect.py
+++ b/colordetect/video_color_detect.py
@@ -97,6 +97,5 @@ class VideoColor:
             )  # Cater for video with extra millis at the end that don't sum upto a full sec, and are thus skipped
 
         self.video_file.release()
-        cv2.destroyAllWindows()
         print("\n")
         return self.color_description


### PR DESCRIPTION
Address local tests passing and remote tests failing.

closes #25 